### PR TITLE
Fix for deleted columns

### DIFF
--- a/FluentMigrator.NHibernate/DifferentialMigration.cs
+++ b/FluentMigrator.NHibernate/DifferentialMigration.cs
@@ -289,7 +289,7 @@ namespace FluentMigrator.NHibernate
                 {
                     From = f,
                     To = to.Columns.FirstOrDefault(t => AreSameColumnName(f, t))
-                }).Where(x => !AreSameColumnDef(x.From, x.To)).ToList();
+                }).Where(x => x.From != null && x.To != null && !AreSameColumnDef(x.From, x.To)).ToList();
             var updatedCols = matches
                 .Select(x => new AlterColumnExpression
                 {


### PR DESCRIPTION
When a column is deleted in a non-first migration, it throws a nullreference exception. This commit fixes that.